### PR TITLE
feat: trade notes UI overhaul

### DIFF
--- a/firefox/popup/popup.css
+++ b/firefox/popup/popup.css
@@ -46,6 +46,62 @@ header h1 {
   color: #888;
 }
 
+.settings-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+  margin-top: 4px;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  background: #252542;
+  padding: 4px;
+  border-radius: 8px;
+}
+
+.tab {
+  flex: 1;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #888;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tab:hover {
+  color: #ccc;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.tab.active {
+  background: #02A9DE;
+  color: white;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.settings-panel {
+  background: #252542;
+  border-radius: 8px;
+  padding: 12px;
+}
+
 .section {
   margin-bottom: 12px;
 }
@@ -224,6 +280,10 @@ header h1 {
 
 .btn.text:hover {
   color: #f44336;
+}
+
+.btn.full-width {
+  width: 100%;
 }
 
 /* Levels List */

--- a/firefox/popup/popup.html
+++ b/firefox/popup/popup.html
@@ -17,8 +17,8 @@
       <div id="status" class="status"></div>
     </header>
 
-    <!-- Main Action Section -->
-    <section id="main-action" class="section hero">
+    <!-- Status Section -->
+    <section id="status-section" class="section hero">
       <div id="tv-status" class="tv-status">
         <span class="indicator"></span>
         <span class="text">Checking TradingView...</span>
@@ -31,77 +31,35 @@
         <span class="text">Checking VL login...</span>
       </div>
 
-      <button id="fetch-draw-btn" class="btn primary large" disabled>
-        🚀 Fetch & Draw VL Levels
-      </button>
-
-      <button id="fetch-trades-btn" class="btn secondary large" disabled>
-        ⭕ Fetch & Draw Large Trades
-      </button>
-
       <div class="button-row">
-        <button id="clear-chart-btn" class="btn secondary" disabled>
-          🗑️ Clear Chart
+        <button id="fetch-draw-btn" class="btn primary" disabled>
+          📈 Draw Levels
         </button>
-        <button id="refresh-btn" class="btn secondary">
-          🔄 Refresh
+        <button id="fetch-trades-btn" class="btn primary" disabled>
+          📝 Draw Trades
         </button>
       </div>
+
+      <button id="clear-chart-btn" class="btn secondary full-width" disabled>
+        🗑️ Clear Chart
+      </button>
     </section>
 
-    <!-- Cached Levels Section -->
-    <section id="levels-section" class="section collapsible">
-      <h2 class="section-header" data-toggle="levels-content">
-        Cached Levels <span id="level-count" class="badge">0</span>
-        <span class="chevron">▼</span>
-      </h2>
-      <div id="levels-content" class="section-content collapsed">
-        <div id="levels-list" class="levels-list">
-          <div class="empty">No levels cached yet.</div>
-        </div>
-        <div class="button-row">
-          <button id="draw-cached-btn" class="btn small" disabled>Draw Cached</button>
-          <button id="clear-cache-btn" class="btn small text">Clear Cache</button>
-        </div>
-      </div>
-    </section>
+    <!-- Tab Navigation -->
+    <div class="settings-label">⚙️ Settings</div>
+    <nav class="tabs">
+      <button class="tab active" data-tab="levels">📈 Levels</button>
+      <button class="tab" data-tab="trades">📝 Trades</button>
+    </nav>
 
-    <!-- Manual Entry Section -->
-    <section class="section collapsible">
-      <h2 class="section-header" data-toggle="manual-content">
-        Manual Entry
-        <span class="chevron">▼</span>
-      </h2>
-      <div id="manual-content" class="section-content collapsed">
-        <div class="input-group">
-          <input type="text" id="symbol-input" placeholder="Symbol (e.g., AAPL)">
-          <input type="number" id="price-input" placeholder="Price" step="0.01">
-          <button id="add-btn" class="btn small">+ Add</button>
-        </div>
-      </div>
-    </section>
-
-    <!-- Settings Section -->
-    <section class="section collapsible">
-      <h2 class="section-header" data-toggle="settings-content">
-        ⚙️ Settings
-        <span class="chevron">▼</span>
-      </h2>
-      <div id="settings-content" class="section-content collapsed">
+    <!-- Levels Tab -->
+    <div id="levels-tab" class="tab-content active">
+      <div class="settings-panel">
         <div class="setting-row">
-          <label for="level-count-select">Number of VL levels:</label>
+          <label for="level-count-select">Number of levels:</label>
           <select id="level-count-select" class="setting-select">
             <option value="5">5 levels</option>
             <option value="10" selected>10 levels</option>
-          </select>
-        </div>
-        <div class="setting-row">
-          <label for="trade-count-select">Number of large trades:</label>
-          <select id="trade-count-select" class="setting-select">
-            <option value="5" selected>5 trades</option>
-            <option value="10">10 trades</option>
-            <option value="15">15 trades</option>
-            <option value="20">20 trades</option>
           </select>
         </div>
         <div class="setting-row">
@@ -134,7 +92,7 @@
         </div>
         <div class="setting-row">
           <label for="line-color-input">Line color:</label>
-          <input type="text" id="line-color-input" class="setting-text" value="#02A9DE" placeholder="#02A9DE" maxlength="7">
+          <input type="text" id="line-color-input" class="setting-text" value="#2962FF" placeholder="#2962FF" maxlength="7">
         </div>
         <div class="setting-row">
           <label for="line-thickness-select">Line thickness:</label>
@@ -153,7 +111,22 @@
           </label>
         </div>
       </div>
-    </section>
+    </div>
+
+    <!-- Trades Tab -->
+    <div id="trades-tab" class="tab-content">
+      <div class="settings-panel">
+        <div class="setting-row">
+          <label for="trade-count-select">Number of trades:</label>
+          <select id="trade-count-select" class="setting-select">
+            <option value="5" selected>5 trades</option>
+            <option value="10">10 trades</option>
+            <option value="15">15 trades</option>
+            <option value="20">20 trades</option>
+          </select>
+        </div>
+      </div>
+    </div>
 
     <footer>
       <label class="toggle">


### PR DESCRIPTION
## Summary

- Replace trade circles with TradingView `text_note` shapes showing rank and dollar volume
- Redesign popup UI with tab-based settings layout (Levels/Trades tabs)
- Remove caching layer - extension now fetches fresh data each request
- Dark pool trades display orange with black text, lit trades blue with white text

## Changes

- **Popup UI**: Remove accordion sections, caching UI, manual entry. Add clean tab navigation.
- **Trade markers**: Use `text_note` shapes at 135° angle instead of circles
- **Visible range**: Skip trades outside chart's visible time range
- **Default color**: Change line color from VL cyan to TradingView blue (#2962FF)