### PR TITLE
feat: add configurable trade rays

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -13,6 +13,8 @@ const VL_API_PATTERNS = [
   '*://volumeleaders.com/api/*'
 ];
 
+const VL_TRADES_TIMEOUT_MS = 60000;
+
 let debugMode = true;
 let xsrfToken = null;
 let xsrfTokenExpiry = 0;
@@ -218,7 +220,7 @@ function handleMessage(message, sender, sendResponse) {
     case 'FETCH_VL_TRADES':
       // Fetch large trades from VL API for circles
       // If tabId is provided, also draw the circles on that tab
-      fetchAndDrawTrades(message.symbol, message.tabId, message.tradeCount)
+      fetchAndDrawTrades(message.symbol, message.tabId, message.tradeCount, message.drawOptions)
         .then(result => sendResponse(result))
         .catch(err => sendResponse({ success: false, error: err.message }));
       return true; // Async response
@@ -324,7 +326,7 @@ async function getXsrfToken(forceRefresh = false) {
 /**
  * Fetch trade levels directly from VolumeLeaders API
  */
-async function fetchVlLevels(ticker) {
+async function fetchVlLevels(ticker, now = new Date()) {
   if (!ticker) {
     throw new Error('No ticker symbol provided');
   }
@@ -338,8 +340,9 @@ async function fetchVlLevels(ticker) {
   console.log(`🔍 Fetching VL levels for ${ticker}...`);
 
   // Get user's settings
-  const settings = await browser.storage.local.get(['levelCount', 'yearRange']);
+  const settings = await browser.storage.local.get(['levelCount', 'tradeCount', 'yearRange']);
   const levelCount = String(settings.levelCount ?? 10);
+  const tradeCount = String(settings.tradeCount ?? 5);
   const yearRange = settings.yearRange ?? 5;
 
   // Check authentication first
@@ -352,91 +355,84 @@ async function fetchVlLevels(ticker) {
   const token = await getXsrfToken();
 
   // Build the request body (DataTables format)
-  const now = new Date();
+  now = now || new Date();
   const today = now.toISOString().split('T')[0];
   const startDate = new Date(now.getFullYear() - yearRange, now.getMonth(), now.getDate())
     .toISOString().split('T')[0];
+  const chartUrl = buildChart0Url(ticker, startDate, today, levelCount, tradeCount);
   const params = new URLSearchParams({
-    'draw': '1',
+    'draw': '2',
     'columns[0][data]': 'Price',
     'columns[0][name]': 'Price',
     'columns[0][searchable]': 'true',
-    'columns[0][orderable]': 'true',
+    'columns[0][orderable]': 'false',
     'columns[0][search][value]': '',
     'columns[0][search][regex]': 'false',
     'columns[1][data]': 'Dollars',
     'columns[1][name]': '$$',
     'columns[1][searchable]': 'true',
-    'columns[1][orderable]': 'true',
+    'columns[1][orderable]': 'false',
     'columns[1][search][value]': '',
     'columns[1][search][regex]': 'false',
     'columns[2][data]': 'Volume',
-    'columns[2][name]': 'Shares',
+    'columns[2][name]': 'Sh',
     'columns[2][searchable]': 'true',
-    'columns[2][orderable]': 'true',
+    'columns[2][orderable]': 'false',
     'columns[2][search][value]': '',
     'columns[2][search][regex]': 'false',
     'columns[3][data]': 'Trades',
     'columns[3][name]': 'Trades',
     'columns[3][searchable]': 'true',
-    'columns[3][orderable]': 'true',
+    'columns[3][orderable]': 'false',
     'columns[3][search][value]': '',
     'columns[3][search][regex]': 'false',
     'columns[4][data]': 'RelativeSize',
     'columns[4][name]': 'RS',
     'columns[4][searchable]': 'true',
-    'columns[4][orderable]': 'true',
+    'columns[4][orderable]': 'false',
     'columns[4][search][value]': '',
     'columns[4][search][regex]': 'false',
     'columns[5][data]': 'CumulativeDistribution',
     'columns[5][name]': 'PCT',
     'columns[5][searchable]': 'true',
-    'columns[5][orderable]': 'true',
+    'columns[5][orderable]': 'false',
     'columns[5][search][value]': '',
     'columns[5][search][regex]': 'false',
     'columns[6][data]': 'TradeLevelRank',
-    'columns[6][name]': 'Level Rank',
+    'columns[6][name]': 'Rank',
     'columns[6][searchable]': 'true',
-    'columns[6][orderable]': 'true',
+    'columns[6][orderable]': 'false',
     'columns[6][search][value]': '',
     'columns[6][search][regex]': 'false',
-    'columns[7][data]': 'Level Date Range',
-    'columns[7][name]': 'Level Date Range',
+    'columns[7][data]': 'Dates',
+    'columns[7][name]': 'Dates',
     'columns[7][searchable]': 'true',
     'columns[7][orderable]': 'false',
     'columns[7][search][value]': '',
     'columns[7][search][regex]': 'false',
-    'order[0][column]': '1',
-    'order[0][dir]': 'DESC',
     'start': '0',
     'length': '-1',
     'search[value]': '',
     'search[regex]': 'false',
+    'StartDate': startDate,
+    'EndDate': today,
     'Ticker': ticker,
-    'MinVolume': '0',
-    'MaxVolume': '2000000000',
-    'MinPrice': '0',
-    'MaxPrice': '100000',
-    'MinDollars': '500000',
-    'MaxDollars': '300000000000',
-    'MinDate': startDate,
-    'MaxDate': today,
-    'VCD': '0',
-    'RelativeSize': '0',
-    'TradeLevelRank': levelCount,
-    'TradeLevelCount': levelCount
+    'Levels': levelCount
   });
 
   try {
-    const response = await fetch('https://www.volumeleaders.com/TradeLevels/GetTradeLevels', {
+    const response = await fetch('https://www.volumeleaders.com/Chart0/GetTradeLevels', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'Accept': 'application/json, text/javascript, */*; q=0.01',
+        'Origin': 'https://www.volumeleaders.com',
+        'Referer': chartUrl,
         'X-XSRF-TOKEN': token,
         'X-Requested-With': 'XMLHttpRequest'
       },
       credentials: 'include',
+      referrer: chartUrl,
       body: params.toString()
     });
 
@@ -564,7 +560,7 @@ async function fetchAndDraw(symbol, tabId = null, drawOptions = {}) {
 /**
  * Fetch large trades from VolumeLeaders API (for circles)
  */
-async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null) {
+async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null, now = new Date()) {
   if (!ticker) {
     throw new Error('No ticker symbol provided');
   }
@@ -583,23 +579,23 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null) {
 
   const token = await getXsrfToken();
 
-  let startDate, endDate;
+  let yearRange = 5;
+  if (!visibleRange || !visibleRange.from || !visibleRange.to) {
+    const settings = await browser.storage.local.get(['yearRange']);
+    yearRange = settings.yearRange ?? 5;
+  }
+
+  const { startDate, endDate } = getTradeDateRange(visibleRange, yearRange, now);
   if (visibleRange && visibleRange.from && visibleRange.to) {
-    startDate = new Date(visibleRange.from * 1000).toISOString().split('T')[0];
-    endDate = new Date(visibleRange.to * 1000).toISOString().split('T')[0];
     console.log(`📅 Using chart visible range: ${startDate} to ${endDate}`);
   } else {
-    const settings = await browser.storage.local.get(['yearRange']);
-    const yearRange = settings.yearRange ?? 5;
-    const now = new Date();
-    endDate = now.toISOString().split('T')[0];
-    startDate = new Date(now.getFullYear() - yearRange, now.getMonth(), now.getDate())
-      .toISOString().split('T')[0];
     console.log(`📅 Using default range (${yearRange}yr): ${startDate} to ${endDate}`);
   }
 
+  const chartUrl = buildChart0Url(ticker, startDate, endDate, tradeCount);
+
   const params = new URLSearchParams({
-    'draw': '1',
+    'draw': '2',
     'columns[0][data]': 'FullTimeString24',
     'columns[0][name]': 'FullTimeString24',
     'columns[0][searchable]': 'true',
@@ -631,63 +627,79 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null) {
     'columns[4][search][value]': '',
     'columns[4][search][regex]': 'false',
     'columns[5][data]': 'TradeRank',
-    'columns[5][name]': 'Rank',
+    'columns[5][name]': 'R',
     'columns[5][searchable]': 'true',
     'columns[5][orderable]': 'false',
     'columns[5][search][value]': '',
     'columns[5][search][regex]': 'false',
     'columns[6][data]': 'LastComparibleTradeDate',
-    'columns[6][name]': 'Last Date',
+    'columns[6][name]': 'Last Comp',
     'columns[6][searchable]': 'true',
     'columns[6][orderable]': 'false',
     'columns[6][search][value]': '',
     'columns[6][search][regex]': 'false',
-    'order[0][column]': '0',
-    'order[0][dir]': 'DESC',
     'start': '0',
     'length': String(tradeCount),
     'search[value]': '',
     'search[regex]': 'false',
-    'Tickers': ticker,
-    'StartDate': startDate,
-    'EndDate': endDate,
+    'StartDateKey': dateKey(startDate),
+    'EndDateKey': dateKey(endDate),
+    'Ticker': ticker,
+    'VolumeProfile': '0',
+    'Levels': String(tradeCount),
     'MinVolume': '0',
     'MaxVolume': '2000000000',
-    'MinPrice': '0',
-    'MaxPrice': '100000',
     'MinDollars': '500000',
-    'MaxDollars': '300000000000',
-    'Conditions': '-1',
-    'VCD': '0',
-    'RelativeSize': '0',
+    'MaxDollars': '30000000000',
     'DarkPools': '-1',
     'Sweeps': '-1',
     'LatePrints': '-1',
-    'SignaturePrints': '0',
+    'SignaturePrints': '-1',
+    'TradeCount': String(tradeCount),
+    'MinPrice': '0',
+    'MaxPrice': '100000',
+    'VCD': '0',
     'TradeRank': '-1',
+    'TradeRankSnapshot': '-1',
     'IncludePremarket': '1',
     'IncludeRTH': '1',
     'IncludeAH': '1',
     'IncludeOpening': '1',
     'IncludeClosing': '1',
     'IncludePhantom': '1',
-    'IncludeOffsetting': '1',
-    'SectorIndustry': '',
-    'Sort': 'Dollars'
+    'IncludeOffsetting': '1'
   });
 
+  console.log('📤 VL Trades request:', {
+    ticker,
+    startDate,
+    endDate,
+    tradeCount,
+    requestUrl: 'https://www.volumeleaders.com/Chart0/GetTrades',
+    referer: chartUrl,
+    bodyLength: params.toString().length
+  });
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), VL_TRADES_TIMEOUT_MS);
+
   try {
-    const response = await fetch('https://www.volumeleaders.com/Trades/GetTrades', {
+    const response = await fetch('https://www.volumeleaders.com/Chart0/GetTrades', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        'Accept': 'application/json, text/javascript, */*; q=0.01',
+        'Origin': 'https://www.volumeleaders.com',
+        'Referer': chartUrl,
         'X-XSRF-TOKEN': token,
         'X-Requested-With': 'XMLHttpRequest'
       },
       credentials: 'include',
+      referrer: chartUrl,
+      signal: controller.signal,
       body: params.toString()
     });
+    clearTimeout(timeoutId);
 
     console.log(`📡 VL Trades API response status: ${response.status}`);
 
@@ -727,8 +739,10 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null) {
         timestamp, // Unix seconds for TradingView
         rank: item.TradeRank,
         dollars: item.Dollars,
+        dollarVolume: item.Dollars,
         volume: item.Volume,
-        darkPool: item.DarkPool === 1,
+        darkPool: isVlFlagEnabled(item.DarkPool),
+        sweep: isVlFlagEnabled(item.Sweep),
         fullDateTime: item.FullDateTime,
         source: `trades-fetch:${ticker}`
       };
@@ -744,12 +758,79 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null) {
     };
 
   } catch (err) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      const timeoutSeconds = VL_TRADES_TIMEOUT_MS / 1000;
+      console.error(`❌ VL Trades API timed out after ${timeoutSeconds} seconds`);
+      throw new Error(`VolumeLeaders trades request timed out after ${timeoutSeconds} seconds`);
+    }
+
     console.error(`❌ Failed to fetch VL trades for ${ticker}:`, err);
     throw err;
   }
 }
 
-async function fetchAndDrawTrades(symbol, tabId = null, tradeCount = 5) {
+function isVlFlagEnabled(value) {
+  return value === 1 || value === true || value === '1' || value === 'true' || value === 'True';
+}
+
+function getTradeDateRange(visibleRange = null, yearRange = 5, now = new Date()) {
+  const today = now.toISOString().split('T')[0];
+
+  if (visibleRange && visibleRange.from && visibleRange.to) {
+    const startDate = new Date(visibleRange.from * 1000).toISOString().split('T')[0];
+    const visibleEndDate = new Date(visibleRange.to * 1000).toISOString().split('T')[0];
+
+    return {
+      startDate,
+      endDate: visibleEndDate > today ? today : visibleEndDate
+    };
+  }
+
+  const startDate = new Date(now.getFullYear() - yearRange, now.getMonth(), now.getDate())
+    .toISOString().split('T')[0];
+
+  return { startDate, endDate: today };
+}
+
+function dateKey(dateString) {
+  return dateString.replaceAll('-', '');
+}
+
+function buildChart0Url(ticker, startDate, endDate, levels, tradeCount = levels) {
+  const query = new URLSearchParams({
+    'StartDate': startDate,
+    'EndDate': endDate,
+    'Ticker': ticker,
+    'MinVolume': '0',
+    'MaxVolume': '2000000000',
+    'MinDollars': '500000',
+    'MaxDollars': '30000000000',
+    'MinPrice': '0',
+    'MaxPrice': '100000',
+    'DarkPools': '-1',
+    'Sweeps': '-1',
+    'LatePrints': '-1',
+    'SignaturePrints': '-1',
+    'VolumeProfile': '0',
+    'Levels': String(levels),
+    'TradeCount': String(tradeCount),
+    'VCD': '0',
+    'TradeRank': '-1',
+    'TradeRankSnapshot': '-1',
+    'IncludePremarket': '1',
+    'IncludeRTH': '1',
+    'IncludeAH': '1',
+    'IncludeOpening': '1',
+    'IncludeClosing': '1',
+    'IncludePhantom': '1',
+    'IncludeOffsetting': '1'
+  });
+
+  return `https://www.volumeleaders.com/Chart0?${query.toString()}`;
+}
+
+async function fetchAndDrawTrades(symbol, tabId = null, tradeCount = 5, drawOptions = {}) {
   let visibleRange = null;
 
   if (tabId) {
@@ -764,7 +845,7 @@ async function fetchAndDrawTrades(symbol, tabId = null, tradeCount = 5) {
     }
   }
 
-  const fetchResult = await fetchVlTrades(symbol, tradeCount, visibleRange);
+  const fetchResult = await fetchVlTrades(symbol, tradeCount);
 
   if (!fetchResult.success || fetchResult.trades.length === 0) {
     return fetchResult;
@@ -776,7 +857,8 @@ async function fetchAndDrawTrades(symbol, tabId = null, tradeCount = 5) {
 
       const drawResponse = await browser.tabs.sendMessage(tabId, {
         type: 'DRAW_NOTES',
-        trades: fetchResult.trades
+        trades: fetchResult.trades,
+        options: drawOptions || {}
       });
 
       console.log(`📝 BACKGROUND: Note draw complete:`, drawResponse);

--- a/firefox/content-script.js
+++ b/firefox/content-script.js
@@ -255,7 +255,8 @@ if (window !== window.top) {
           timestamp: trade.timestamp,
           rank: trade.rank,
           darkPool: trade.darkPool,
-          dollarVolume: trade.dollarVolume,
+          sweep: trade.sweep,
+          dollarVolume: trade.dollarVolume ?? trade.dollars,
           options: options
         });
 

--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -291,11 +291,8 @@
   }
 
   /**
-   * Draw a text note on the chart for a large trade
-   * Uses createShape with a single point (price + time)
-   *
-   * If the trade's timestamp is before the visible chart range,
-   * draws at the left edge with a "←" indicator in the label
+   * Draw a horizontal ray on the chart for a large trade.
+   * Uses the actual trade timestamp as the ray start point.
    */
   async function drawNote(data) {
     const chart = getChartApi();
@@ -305,7 +302,7 @@
       throw new Error(error);
     }
 
-    const { price, timestamp, rank, darkPool, dollarVolume, options = {} } = data;
+    const { price, timestamp, rank, darkPool, sweep, dollarVolume, options = {} } = data;
 
     const visibleRange = getVisibleTimeRange();
     if (visibleRange) {
@@ -316,8 +313,8 @@
     }
 
     const color = darkPool
-      ? (options.darkPoolColor || 'rgba(255, 152, 0, 1)')
-      : (options.litColor || 'rgba(41, 98, 255, 1)');
+      ? (options.tradeDarkPoolColor || 'rgba(255, 152, 0, 1)')
+      : (options.tradeLitColor || 'rgba(41, 98, 255, 1)');
 
     let volLabel = '';
     if (dollarVolume) {
@@ -328,47 +325,40 @@
       }
     }
 
-    const labelText = `VL #${rank}${volLabel}`;
-
-    const textColor = darkPool ? 'rgba(0, 0, 0, 1)' : 'rgba(255, 255, 255, 1)';
+    const marker = sweep ? '◆' : '●';
+    const labelText = `${marker} VL #${rank}${volLabel}`;
 
     const overrides = {
-      lineColor: color,
-      backgroundColor: color,
-      textColor: options.textColor || textColor,
-      drawBackground: true,
-      drawBorder: false,
-      fontSize: options.fontSize || 14,
+      linecolor: color,
+      linewidth: options.tradeThickness || 2,
+      linestyle: options.linestyle || 0,
+      showLabel: true,
+      textcolor: options.textcolor || color,
+      fontsize: options.fontsize || 12,
       bold: options.bold !== false
     };
 
     const shapeConfig = {
-      shape: 'text_note',
+      shape: 'horizontal_ray',
       text: labelText,
       zOrder: 'top',
       overrides: overrides
     };
 
-    // Two points: [0] = anchor on bar, [1] = note label position (down-right like IRE #2)
-    const points = [
-      { price: price, time: timestamp },
-      { price: price * 0.92, time: timestamp + 6 * 24 * 60 * 60 }
-    ];
-
-    console.log(`📝 INJECTED v2: shape=${shapeConfig.shape}, price=$${price.toFixed(2)}, time=${timestamp}, rank=#${rank}`);
+    console.log(`📝 INJECTED v3: shape=${shapeConfig.shape}, price=$${price.toFixed(2)}, time=${timestamp}, rank=#${rank}`);
 
     try {
-      const shapeId = await chart.createMultipointShape(points, shapeConfig);
+      const shapeId = await chart.createShape({ price: price, time: timestamp }, shapeConfig);
 
       if (!shapeId) {
         console.warn('⚠️ createShape returned falsy value:', shapeId);
         throw new Error('createShape returned no ID');
       }
 
-      console.log(`✅ Drew note at $${price.toFixed(2)}, ID: ${shapeId}`);
+      console.log(`✅ Drew trade ray at $${price.toFixed(2)}, ID: ${shapeId}`);
       return { shapeId, price, timestamp, rank };
     } catch (err) {
-      console.error('❌ Failed to draw note at', price);
+      console.error('❌ Failed to draw trade ray at', price);
       console.error('❌ Error:', err.message || err);
       throw err;
     }
@@ -495,8 +485,8 @@
   }
 
   /**
-   * Remove only VL text_note shapes (not horizontal lines)
-   * This clears previous VL notes before drawing new ones
+   * Remove only VL trade marker shapes (not horizontal lines).
+   * Clears current horizontal rays and legacy text notes before drawing new trades.
    */
   async function clearVlNotes() {
     const chart = getChartApi();
@@ -506,11 +496,11 @@
 
     try {
       const allShapes = chart.getAllShapes();
-      console.log(`🔍 Checking ${allShapes.length} shapes for VL notes...`);
+      console.log(`🔍 Checking ${allShapes.length} shapes for VL trade markers...`);
 
       for (const shape of allShapes) {
         try {
-          if (shape.name !== 'text_note') continue;
+          if (shape.name !== 'horizontal_ray' && shape.name !== 'text_note') continue;
 
           const shapeObj = chart.getShapeById(shape.id);
           if (!shapeObj) continue;
@@ -518,21 +508,25 @@
           const props = shapeObj.getProperties ? shapeObj.getProperties() : null;
           const text = props?.text || '';
 
-          if (text.startsWith('VL')) {
+          if (isVlTradeText(text)) {
             chart.removeEntity(shape.id);
             removed++;
-            console.log(`🗑️ Removed VL note: ${shape.id} ("${text}")`);
+            console.log(`🗑️ Removed VL trade marker: ${shape.id} ("${text}")`);
           }
         } catch (e) {
           // Shape might not have text or be accessible
         }
       }
     } catch (e) {
-      console.error('Error clearing VL notes:', e);
+      console.error('Error clearing VL trade markers:', e);
     }
 
-    console.log(`✅ Cleared ${removed} VL notes`);
+    console.log(`✅ Cleared ${removed} VL trade markers`);
     return { removed };
+  }
+
+  function isVlTradeText(text) {
+    return text.startsWith('VL') || text.startsWith('● VL') || text.startsWith('◆ VL');
   }
 
   /**

--- a/firefox/popup/popup.html
+++ b/firefox/popup/popup.html
@@ -125,6 +125,24 @@
             <option value="20">20 trades</option>
           </select>
         </div>
+        <div class="setting-row">
+          <label for="trade-lit-color-input">Lit trade color:</label>
+          <input type="text" id="trade-lit-color-input" class="setting-text" value="#2962FF" placeholder="#2962FF" maxlength="7">
+        </div>
+        <div class="setting-row">
+          <label for="trade-dark-pool-color-input">Dark pool color:</label>
+          <input type="text" id="trade-dark-pool-color-input" class="setting-text" value="#FF9800" placeholder="#FF9800" maxlength="7">
+        </div>
+        <div class="setting-row">
+          <label for="trade-thickness-select">Trade thickness:</label>
+          <select id="trade-thickness-select" class="setting-select">
+            <option value="1">1px (thin)</option>
+            <option value="2" selected>2px (default)</option>
+            <option value="3">3px (medium)</option>
+            <option value="4">4px (thick)</option>
+            <option value="5">5px (very thick)</option>
+          </select>
+        </div>
       </div>
     </div>
 

--- a/firefox/popup/popup.js
+++ b/firefox/popup/popup.js
@@ -56,6 +56,9 @@ const elements = {
   debugToggle: document.getElementById('debug-toggle'),
   levelCountSelect: document.getElementById('level-count-select'),
   tradeCountSelect: document.getElementById('trade-count-select'),
+  tradeLitColorInput: document.getElementById('trade-lit-color-input'),
+  tradeDarkPoolColorInput: document.getElementById('trade-dark-pool-color-input'),
+  tradeThicknessSelect: document.getElementById('trade-thickness-select'),
   yearRangeSelect: document.getElementById('year-range-select'),
   clusteringToggle: document.getElementById('clustering-toggle'),
   thresholdSelect: document.getElementById('threshold-select'),
@@ -95,11 +98,14 @@ async function init() {
   // Load settings
   const stored = await browser.storage.local.get([
     'debugMode', 'levelCount', 'tradeCount', 'yearRange', 'clusteringEnabled', 'clusterThreshold',
-    'lineColor', 'lineThickness', 'showDates'
+    'lineColor', 'lineThickness', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness'
   ]);
   elements.debugToggle.checked = stored.debugMode || false;
   elements.levelCountSelect.value = stored.levelCount ?? 10;
   elements.tradeCountSelect.value = stored.tradeCount ?? 5;
+  elements.tradeLitColorInput.value = stored.tradeLitColor ?? '#2962FF';
+  elements.tradeDarkPoolColorInput.value = stored.tradeDarkPoolColor ?? '#FF9800';
+  elements.tradeThicknessSelect.value = stored.tradeThickness ?? 2;
   elements.yearRangeSelect.value = stored.yearRange ?? 5;
   elements.clusteringToggle.checked = stored.clusteringEnabled !== false; // Default true
   elements.thresholdSelect.value = stored.clusterThreshold ?? 1.0;
@@ -286,16 +292,22 @@ async function fetchAndDrawTrades() {
   elements.status.textContent = `Fetching large trades for ${currentSymbol}...`;
 
   try {
-    // Get trade count setting
-    const stored = await browser.storage.local.get(['tradeCount']);
-    const tradeCount = stored.tradeCount ?? 5;
+    const tradeCount = parseInt(elements.tradeCountSelect?.value, 10) || 5;
+    const tradeLitColor = normalizeColorForDraw(elements.tradeLitColorInput?.value, '#2962FF');
+    const tradeDarkPoolColor = normalizeColorForDraw(elements.tradeDarkPoolColorInput?.value, '#FF9800');
+    const tradeThickness = parseInt(elements.tradeThicknessSelect?.value, 10) || 2;
 
     // Send fetch request with tabId - background script handles drawing
     const response = await browser.runtime.sendMessage({
       type: 'FETCH_VL_TRADES',
       symbol: currentSymbol,
       tabId: currentTabId,
-      tradeCount: tradeCount
+      tradeCount: tradeCount,
+      drawOptions: {
+        tradeLitColor,
+        tradeDarkPoolColor,
+        tradeThickness
+      }
     });
 
     if (!response.success) {
@@ -374,6 +386,53 @@ async function handleTradeCountChange() {
   const tradeCount = parseInt(elements.tradeCountSelect.value, 10);
   await browser.storage.local.set({ tradeCount });
   console.log('⚙️ Trade count set to:', tradeCount);
+}
+
+function normalizeColorForDraw(value, fallback) {
+  let color = value?.trim().toUpperCase() || fallback;
+  if (color && !color.startsWith('#')) {
+    color = '#' + color;
+  }
+
+  return /^#[0-9A-F]{6}$/.test(color) ? color : fallback;
+}
+
+async function handleTradeLitColorChange() {
+  let color = elements.tradeLitColorInput.value.trim().toUpperCase();
+
+  if (color && !color.startsWith('#')) {
+    color = '#' + color;
+    elements.tradeLitColorInput.value = color;
+  }
+
+  if (!/^#[0-9A-F]{6}$/.test(color)) {
+    return;
+  }
+
+  await browser.storage.local.set({ tradeLitColor: color });
+  console.log('🎨 Lit trade color set to:', color);
+}
+
+async function handleTradeDarkPoolColorChange() {
+  let color = elements.tradeDarkPoolColorInput.value.trim().toUpperCase();
+
+  if (color && !color.startsWith('#')) {
+    color = '#' + color;
+    elements.tradeDarkPoolColorInput.value = color;
+  }
+
+  if (!/^#[0-9A-F]{6}$/.test(color)) {
+    return;
+  }
+
+  await browser.storage.local.set({ tradeDarkPoolColor: color });
+  console.log('🎨 Dark pool trade color set to:', color);
+}
+
+async function handleTradeThicknessChange() {
+  const thickness = parseInt(elements.tradeThicknessSelect.value, 10);
+  await browser.storage.local.set({ tradeThickness: thickness });
+  console.log('⚙️ Trade thickness set to:', thickness);
 }
 
 /**
@@ -472,6 +531,9 @@ function setupEventListeners() {
   elements.lineColorInput.addEventListener('input', handleLineColorChange);
   elements.lineThicknessSelect.addEventListener('change', handleLineThicknessChange);
   elements.showDatesToggle.addEventListener('change', handleShowDatesToggle);
+  elements.tradeLitColorInput.addEventListener('input', handleTradeLitColorChange);
+  elements.tradeDarkPoolColorInput.addEventListener('input', handleTradeDarkPoolColorChange);
+  elements.tradeThicknessSelect.addEventListener('change', handleTradeThicknessChange);
 
   // Tab switching
   document.querySelectorAll('.tab').forEach(tab => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.0",
   "description": "Draw VolumeLeaders trade levels on TradingView charts",
   "scripts": {
+    "test": "node --test",
     "build": "web-ext build --source-dir=firefox --artifacts-dir=build --overwrite-dest && npm run rename-artifacts",
     "rename-artifacts": "VERSION=$(node -p \"require('./firefox/manifest.json').version\") && mv build/vl_tradingview_bridge-$VERSION.zip build/vl-tv-bridge-$VERSION.zip && cp build/vl-tv-bridge-$VERSION.zip build/vl-tv-bridge-$VERSION.xpi",
     "sign": "web-ext sign --source-dir=firefox --artifacts-dir=build --channel=unlisted --api-key=$WEB_EXT_API_KEY --api-secret=$WEB_EXT_API_SECRET",

--- a/test/background-trade-date-range.test.js
+++ b/test/background-trade-date-range.test.js
@@ -1,0 +1,299 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadBackground(settings = {}) {
+  const fetchCalls = [];
+  const context = vm.createContext({
+    AbortController,
+    URLSearchParams,
+    TextDecoder,
+    TextEncoder,
+    console,
+    fetch: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+
+      if (String(url).includes('/TradeLevels?Ticker=SPY')) {
+        return {
+          ok: true,
+          url: String(url),
+          text: async () => '<input name="__RequestVerificationToken" value="test-token" />'
+        };
+      }
+
+      if (String(url).includes('/Chart0/GetTradeLevels')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ Price: 36.8, TradeLevelRank: 1, Dollars: 1459892.8, Volume: 39671, Trades: 1, Dates: '2026-05-19 - 2026-05-19' }]
+          })
+        };
+      }
+
+      if (String(url).includes('/Chart0/GetTrades')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: settings.tradesData || [] })
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] })
+      };
+    },
+    setTimeout,
+    clearTimeout,
+    browser: {
+      cookies: { getAll: async () => [{ name: '.ASPXAUTH' }] },
+      runtime: { onMessage: { addListener() {} } },
+      storage: { local: { get: async () => settings } },
+      tabs: { sendMessage: async () => ({}) },
+      webRequest: {
+        filterResponseData: () => ({}),
+        onBeforeRequest: { addListener() {} },
+        onBeforeSendHeaders: { addListener() {} }
+      }
+    },
+    tickerMap: { tvToVl: ticker => ticker.toUpperCase() }
+  });
+
+  const script = fs.readFileSync(path.join(__dirname, '..', 'firefox', 'background.js'), 'utf8');
+  vm.runInContext(script, context);
+  context.fetchCalls = fetchCalls;
+  return context;
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('trade visible range end date is clamped to today', () => {
+  const { getTradeDateRange } = loadBackground();
+  const now = new Date('2026-06-08T12:00:00Z');
+
+  const range = getTradeDateRange({
+    from: Date.parse('2025-09-16T00:00:00Z') / 1000,
+    to: Date.parse('2026-07-22T00:00:00Z') / 1000
+  }, 5, now);
+
+  assert.deepEqual(plain(range), {
+    startDate: '2025-09-16',
+    endDate: '2026-06-08'
+  });
+});
+
+test('trade fallback range uses configured year range', () => {
+  const { getTradeDateRange } = loadBackground();
+  const now = new Date('2026-06-08T12:00:00Z');
+
+  assert.deepEqual(plain(getTradeDateRange(null, 2, now)), {
+    startDate: '2024-06-08',
+    endDate: '2026-06-08'
+  });
+});
+
+test('trade request matches the VolumeLeaders Chart0 GetTrades HAR shape', async () => {
+  const context = loadBackground({ yearRange: 1 });
+
+  await context.fetchVlTrades('CRDU', 5, null, new Date('2026-06-08T12:00:00Z'));
+
+  const tradeRequest = context.fetchCalls.find(call => String(call.url).endsWith('/Chart0/GetTrades'));
+  const body = Object.fromEntries(new URLSearchParams(tradeRequest.options.body));
+  const expectedBody = {
+    'draw': '2',
+    'columns[0][data]': 'FullTimeString24',
+    'columns[0][name]': 'FullTimeString24',
+    'columns[0][searchable]': 'true',
+    'columns[0][orderable]': 'false',
+    'columns[0][search][value]': '',
+    'columns[0][search][regex]': 'false',
+    'columns[1][data]': 'Volume',
+    'columns[1][name]': 'Sh',
+    'columns[1][searchable]': 'true',
+    'columns[1][orderable]': 'false',
+    'columns[1][search][value]': '',
+    'columns[1][search][regex]': 'false',
+    'columns[2][data]': 'Price',
+    'columns[2][name]': 'Price',
+    'columns[2][searchable]': 'true',
+    'columns[2][orderable]': 'false',
+    'columns[2][search][value]': '',
+    'columns[2][search][regex]': 'false',
+    'columns[3][data]': 'Dollars',
+    'columns[3][name]': '$$',
+    'columns[3][searchable]': 'true',
+    'columns[3][orderable]': 'false',
+    'columns[3][search][value]': '',
+    'columns[3][search][regex]': 'false',
+    'columns[4][data]': 'DollarsMultiplier',
+    'columns[4][name]': 'RS',
+    'columns[4][searchable]': 'true',
+    'columns[4][orderable]': 'false',
+    'columns[4][search][value]': '',
+    'columns[4][search][regex]': 'false',
+    'columns[5][data]': 'TradeRank',
+    'columns[5][name]': 'R',
+    'columns[5][searchable]': 'true',
+    'columns[5][orderable]': 'false',
+    'columns[5][search][value]': '',
+    'columns[5][search][regex]': 'false',
+    'columns[6][data]': 'LastComparibleTradeDate',
+    'columns[6][name]': 'Last Comp',
+    'columns[6][searchable]': 'true',
+    'columns[6][orderable]': 'false',
+    'columns[6][search][value]': '',
+    'columns[6][search][regex]': 'false',
+    'start': '0',
+    'length': '5',
+    'search[value]': '',
+    'search[regex]': 'false',
+    'StartDateKey': '20250608',
+    'EndDateKey': '20260608',
+    'Ticker': 'CRDU',
+    'VolumeProfile': '0',
+    'Levels': '5',
+    'MinVolume': '0',
+    'MaxVolume': '2000000000',
+    'MinDollars': '500000',
+    'MaxDollars': '30000000000',
+    'DarkPools': '-1',
+    'Sweeps': '-1',
+    'LatePrints': '-1',
+    'SignaturePrints': '-1',
+    'TradeCount': '5',
+    'MinPrice': '0',
+    'MaxPrice': '100000',
+    'VCD': '0',
+    'TradeRank': '-1',
+    'TradeRankSnapshot': '-1',
+    'IncludePremarket': '1',
+    'IncludeRTH': '1',
+    'IncludeAH': '1',
+    'IncludeOpening': '1',
+    'IncludeClosing': '1',
+    'IncludePhantom': '1',
+    'IncludeOffsetting': '1'
+  };
+
+  assert.equal(String(tradeRequest.url), 'https://www.volumeleaders.com/Chart0/GetTrades');
+  assert.equal(tradeRequest.options.headers['Content-Type'], 'application/x-www-form-urlencoded; charset=UTF-8');
+  assert.equal(tradeRequest.options.headers.Accept, 'application/json, text/javascript, */*; q=0.01');
+  assert.equal(tradeRequest.options.headers.Origin, 'https://www.volumeleaders.com');
+  assert.equal(tradeRequest.options.headers.Referer, 'https://www.volumeleaders.com/Chart0?StartDate=2025-06-08&EndDate=2026-06-08&Ticker=CRDU&MinVolume=0&MaxVolume=2000000000&MinDollars=500000&MaxDollars=30000000000&MinPrice=0&MaxPrice=100000&DarkPools=-1&Sweeps=-1&LatePrints=-1&SignaturePrints=-1&VolumeProfile=0&Levels=5&TradeCount=5&VCD=0&TradeRank=-1&TradeRankSnapshot=-1&IncludePremarket=1&IncludeRTH=1&IncludeAH=1&IncludeOpening=1&IncludeClosing=1&IncludePhantom=1&IncludeOffsetting=1');
+  assert.deepEqual(body, expectedBody);
+});
+
+test('trade response maps sweep flag for trade ray labels', async () => {
+  const context = loadBackground({
+    yearRange: 1,
+    tradesData: [{
+      Date: '/Date(1779148800000)/',
+      Ticker: 'CRDU',
+      Price: 36.8,
+      TradeRank: 1,
+      Dollars: 1459892.8,
+      Volume: 39671,
+      DarkPool: 0,
+      Sweep: 1,
+      FullDateTime: '2026-05-19T09:36:02'
+    }, {
+      Date: '/Date(1779148860000)/',
+      Ticker: 'VT',
+      Price: 123.45,
+      TradeRank: 2,
+      Dollars: 2000000,
+      Volume: 10000,
+      DarkPool: '1',
+      Sweep: 1,
+      FullDateTime: '2026-05-19T09:37:02'
+    }]
+  });
+
+  const result = await context.fetchVlTrades('CRDU', 5, null, new Date('2026-06-08T12:00:00Z'));
+
+  assert.equal(result.trades[0].sweep, true);
+  assert.equal(result.trades[1].darkPool, true);
+  assert.equal(result.trades[1].sweep, true);
+});
+
+test('level request matches the VolumeLeaders Chart0 GetTradeLevels HAR shape', async () => {
+  const context = loadBackground({ yearRange: 1, levelCount: 5, tradeCount: 3 });
+
+  const result = await context.fetchVlLevels('CRDU', new Date('2026-06-08T12:00:00Z'));
+
+  const levelRequest = context.fetchCalls.find(call => String(call.url).endsWith('/Chart0/GetTradeLevels'));
+  const body = Object.fromEntries(new URLSearchParams(levelRequest.options.body));
+  const expectedBody = {
+    'draw': '2',
+    'columns[0][data]': 'Price',
+    'columns[0][name]': 'Price',
+    'columns[0][searchable]': 'true',
+    'columns[0][orderable]': 'false',
+    'columns[0][search][value]': '',
+    'columns[0][search][regex]': 'false',
+    'columns[1][data]': 'Dollars',
+    'columns[1][name]': '$$',
+    'columns[1][searchable]': 'true',
+    'columns[1][orderable]': 'false',
+    'columns[1][search][value]': '',
+    'columns[1][search][regex]': 'false',
+    'columns[2][data]': 'Volume',
+    'columns[2][name]': 'Sh',
+    'columns[2][searchable]': 'true',
+    'columns[2][orderable]': 'false',
+    'columns[2][search][value]': '',
+    'columns[2][search][regex]': 'false',
+    'columns[3][data]': 'Trades',
+    'columns[3][name]': 'Trades',
+    'columns[3][searchable]': 'true',
+    'columns[3][orderable]': 'false',
+    'columns[3][search][value]': '',
+    'columns[3][search][regex]': 'false',
+    'columns[4][data]': 'RelativeSize',
+    'columns[4][name]': 'RS',
+    'columns[4][searchable]': 'true',
+    'columns[4][orderable]': 'false',
+    'columns[4][search][value]': '',
+    'columns[4][search][regex]': 'false',
+    'columns[5][data]': 'CumulativeDistribution',
+    'columns[5][name]': 'PCT',
+    'columns[5][searchable]': 'true',
+    'columns[5][orderable]': 'false',
+    'columns[5][search][value]': '',
+    'columns[5][search][regex]': 'false',
+    'columns[6][data]': 'TradeLevelRank',
+    'columns[6][name]': 'Rank',
+    'columns[6][searchable]': 'true',
+    'columns[6][orderable]': 'false',
+    'columns[6][search][value]': '',
+    'columns[6][search][regex]': 'false',
+    'columns[7][data]': 'Dates',
+    'columns[7][name]': 'Dates',
+    'columns[7][searchable]': 'true',
+    'columns[7][orderable]': 'false',
+    'columns[7][search][value]': '',
+    'columns[7][search][regex]': 'false',
+    'start': '0',
+    'length': '-1',
+    'search[value]': '',
+    'search[regex]': 'false',
+    'StartDate': '2025-06-08',
+    'EndDate': '2026-06-08',
+    'Ticker': 'CRDU',
+    'Levels': '5'
+  };
+
+  assert.equal(String(levelRequest.url), 'https://www.volumeleaders.com/Chart0/GetTradeLevels');
+  assert.equal(levelRequest.options.headers['Content-Type'], 'application/x-www-form-urlencoded; charset=UTF-8');
+  assert.equal(levelRequest.options.headers.Accept, 'application/json, text/javascript, */*; q=0.01');
+  assert.equal(levelRequest.options.headers.Origin, 'https://www.volumeleaders.com');
+  assert.equal(levelRequest.options.headers.Referer, 'https://www.volumeleaders.com/Chart0?StartDate=2025-06-08&EndDate=2026-06-08&Ticker=CRDU&MinVolume=0&MaxVolume=2000000000&MinDollars=500000&MaxDollars=30000000000&MinPrice=0&MaxPrice=100000&DarkPools=-1&Sweeps=-1&LatePrints=-1&SignaturePrints=-1&VolumeProfile=0&Levels=5&TradeCount=3&VCD=0&TradeRank=-1&TradeRankSnapshot=-1&IncludePremarket=1&IncludeRTH=1&IncludeAH=1&IncludeOpening=1&IncludeClosing=1&IncludePhantom=1&IncludeOffsetting=1');
+  assert.deepEqual(body, expectedBody);
+  assert.equal(result.levels[0].price, 36.8);
+});

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -1,0 +1,174 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadInjected(chart) {
+  const listeners = { message: [] };
+  const postedMessages = [];
+  const window = {
+    top: null,
+    vlTvBridgeInjected: false,
+    addEventListener(type, handler) {
+      listeners[type].push(handler);
+    },
+    postMessage(message) {
+      postedMessages.push(message);
+    }
+  };
+  window.top = window;
+
+  const context = vm.createContext({
+    console,
+    window,
+    TradingViewApi: {
+      activeChart: () => chart
+    }
+  });
+  const script = fs.readFileSync(path.join(__dirname, '..', 'firefox', 'injected.js'), 'utf8');
+  vm.runInContext(script, context);
+
+  return {
+    postedMessages,
+    async send(command, data = {}) {
+      const event = {
+        source: window,
+        data: {
+          source: 'vl-tv-content',
+          messageId: command,
+          command,
+          data
+        }
+      };
+      await Promise.all(listeners.message.map(handler => handler(event)));
+      return postedMessages.find(message => message.messageId === command);
+    }
+  };
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('DRAW_NOTE creates a horizontal ray from the actual trade timestamp', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return 'ray-1';
+    },
+    createMultipointShape() {
+      throw new Error('text_note path should not be used for trades');
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  const response = await injected.send('DRAW_NOTE', {
+    price: 123.45,
+    timestamp: 1712345678,
+    rank: 2,
+    darkPool: true,
+    dollarVolume: 250000000
+  });
+
+  assert.equal(response.error, null);
+  assert.deepEqual(plain(response.result), {
+    shapeId: 'ray-1',
+    price: 123.45,
+    timestamp: 1712345678,
+    rank: 2
+  });
+  assert.equal(createShapeCalls.length, 1);
+  assert.deepEqual(plain(createShapeCalls[0].point), { price: 123.45, time: 1712345678 });
+  assert.equal(createShapeCalls[0].config.shape, 'horizontal_ray');
+  assert.equal(createShapeCalls[0].config.text, '● VL #2 $250M');
+  assert.equal(createShapeCalls[0].config.overrides.linecolor, 'rgba(255, 152, 0, 1)');
+  assert.equal(createShapeCalls[0].config.overrides.showLabel, true);
+});
+
+test('DRAW_NOTE uses sweep marker and custom trade ray styling', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return `ray-${createShapeCalls.length}`;
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  await injected.send('DRAW_NOTE', {
+    price: 36.8,
+    timestamp: 1712345678,
+    rank: 1,
+    sweep: true,
+    darkPool: false,
+    dollarVolume: 1459892.8,
+    options: {
+      tradeLitColor: '#112233',
+      tradeDarkPoolColor: '#445566',
+      tradeThickness: 4
+    }
+  });
+  await injected.send('DRAW_NOTE', {
+    price: 70.34,
+    timestamp: 1712345679,
+    rank: 3,
+    sweep: false,
+    darkPool: true,
+    dollarVolume: 1360000,
+    options: {
+      tradeLitColor: '#112233',
+      tradeDarkPoolColor: '#445566',
+      tradeThickness: 4
+    }
+  });
+
+  assert.equal(createShapeCalls[0].config.text, '◆ VL #1 $1M');
+  assert.equal(createShapeCalls[0].config.overrides.linecolor, '#112233');
+  assert.equal(createShapeCalls[0].config.overrides.linewidth, 4);
+  assert.equal(createShapeCalls[1].config.text, '● VL #3 $1M');
+  assert.equal(createShapeCalls[1].config.overrides.linecolor, '#445566');
+  assert.equal(createShapeCalls[1].config.overrides.linewidth, 4);
+});
+
+test('CLEAR_VL_NOTES removes existing VL horizontal rays and legacy notes', async () => {
+  const removed = [];
+  const chart = {
+    getAllShapes() {
+      return [
+        { id: 'ray-1', name: 'horizontal_ray' },
+        { id: 'note-1', name: 'text_note' },
+        { id: 'line-1', name: 'horizontal_line' },
+        { id: 'user-ray', name: 'horizontal_ray' }
+      ];
+    },
+    getShapeById(id) {
+      const texts = {
+        'ray-1': '● VL #1 $1B',
+        'note-1': 'VL #2 $250M',
+        'line-1': 'VL 123.45',
+        'user-ray': 'User Ray'
+      };
+      return {
+        getProperties: () => ({ text: texts[id] })
+      };
+    },
+    removeEntity(id) {
+      removed.push(id);
+    }
+  };
+  const injected = loadInjected(chart);
+
+  const response = await injected.send('CLEAR_VL_NOTES');
+
+  assert.equal(response.error, null);
+  assert.deepEqual(plain(response.result), { removed: 2 });
+  assert.deepEqual(removed, ['ray-1', 'note-1']);
+});


### PR DESCRIPTION
## Summary
- Draw VolumeLeaders trades as configurable horizontal rays anchored to the trade timestamp.
- Match VolumeLeaders Chart0 request shape for levels and trades so the extension fetches the same data as the site.
- Add regression coverage for trade request payloads, dark-pool/sweep flags, cleanup, and injected TradingView shape calls.

## Changes
- Add lit trade color, dark-pool color, and trade thickness controls in the popup.
- Render trade labels with sweep and regular-trade markers.
- Add Node test coverage for background request mapping and injected ray rendering.

## Testing
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Local CodeRabbit review, 0 findings

## Related
- None
