### PR TITLE
fix: parse VL trade times as market time

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -14,10 +14,59 @@ const VL_API_PATTERNS = [
 ];
 
 const VL_TRADES_TIMEOUT_MS = 60000;
+const VL_MARKET_TIME_ZONE = 'America/New_York';
 
 let debugMode = true;
 let xsrfToken = null;
 let xsrfTokenExpiry = 0;
+
+function getTimeZoneOffsetMs(timestampMs, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).formatToParts(new Date(timestampMs));
+
+  const values = Object.fromEntries(
+    parts
+      .filter(part => part.type !== 'literal')
+      .map(part => [part.type, Number(part.value)])
+  );
+
+  const zonedTimestampMs = Date.UTC(
+    values.year,
+    values.month - 1,
+    values.day,
+    values.hour,
+    values.minute,
+    values.second
+  );
+
+  return zonedTimestampMs - timestampMs;
+}
+
+function parseVlFullDateTime(fullDateTime) {
+  if (!fullDateTime) return null;
+
+  const match = fullDateTime.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second] = match.map(Number);
+  const localTimestampMs = Date.UTC(year, month - 1, day, hour, minute, second);
+
+  let timestampMs = localTimestampMs;
+  for (let i = 0; i < 2; i += 1) {
+    timestampMs = localTimestampMs - getTimeZoneOffsetMs(timestampMs, VL_MARKET_TIME_ZONE);
+  }
+
+  return timestampMs / 1000;
+}
 
 /**
  * Initialize extension
@@ -730,8 +779,11 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null, now =
     // Parse and store the trades
     const trades = json.data.map(item => {
       // Parse .NET JSON date format: "/Date(1748563200000)/"
+      const fullDateTimestamp = parseVlFullDateTime(item.FullDateTime);
       const dateMatch = item.Date?.match(/\/Date\((\d+)\)\//);
-      const timestamp = dateMatch ? parseInt(dateMatch[1], 10) / 1000 : null;
+      const timestamp = Number.isFinite(fullDateTimestamp)
+        ? fullDateTimestamp
+        : (dateMatch ? parseInt(dateMatch[1], 10) / 1000 : null);
 
       return {
         ticker: item.Ticker || ticker,

--- a/test/background-trade-date-range.test.js
+++ b/test/background-trade-date-range.test.js
@@ -254,6 +254,28 @@ test('trade response maps sweep flag for trade ray labels', async () => {
   assert.equal(result.trades[1].sweep, true);
 });
 
+test('trade response treats FullDateTime as New York market time', async () => {
+  const context = loadBackground({
+    yearRange: 1,
+    tradesData: [{
+      Date: '/Date(1780358400000)/',
+      Ticker: 'BE',
+      Price: 302.85,
+      TradeRank: 4,
+      Dollars: 434165760,
+      Volume: 1433552,
+      DarkPool: 1,
+      Sweep: 0,
+      FullDateTime: '2026-06-02T16:06:57'
+    }]
+  });
+
+  const result = await context.fetchVlTrades('BE', 5, null, new Date('2026-06-11T16:37:00Z'));
+
+  assert.equal(result.trades[0].timestamp, Date.parse('2026-06-02T20:06:57Z') / 1000);
+  assert.equal(result.trades[0].darkPool, true);
+});
+
 test('level request matches the VolumeLeaders Chart0 GetTradeLevels HAR shape', async () => {
   const context = loadBackground({ yearRange: 1, levelCount: 5, tradeCount: 3 });
 


### PR DESCRIPTION
## Summary
- Trade rays were anchoring to the VolumeLeaders date-only epoch instead of the actual trade time, which made some rays appear to change color or identity as the visible range changed.
- VolumeLeaders returns `FullDateTime` in New York market time, so parse that timestamp first and only fall back to the legacy `/Date(...)` field when it is unavailable.

## Changes
- Parse `FullDateTime` as `America/New_York` before mapping VL trades for TradingView.
- Keep the existing `/Date(...)` fallback for responses that do not include `FullDateTime`.
- Add a regression test for the BE dark-pool trade timestamp case.

## Testing
- [x] `npm test`
- [x] `npm run lint`
- [x] CodeRabbit local review: 0 findings

## Related
- None
