### PR TITLE
feat: show original trade rank labels

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -790,6 +790,7 @@ async function fetchVlTrades(ticker, tradeCount = 10, visibleRange = null, now =
         price: item.Price,
         timestamp, // Unix seconds for TradingView
         rank: item.TradeRank,
+        originalRank: item.TradeRankSnapshot,
         dollars: item.Dollars,
         dollarVolume: item.Dollars,
         volume: item.Volume,

--- a/firefox/content-script.js
+++ b/firefox/content-script.js
@@ -254,6 +254,7 @@ if (window !== window.top) {
           price: trade.price,
           timestamp: trade.timestamp,
           rank: trade.rank,
+          originalRank: trade.originalRank,
           darkPool: trade.darkPool,
           sweep: trade.sweep,
           dollarVolume: trade.dollarVolume ?? trade.dollars,

--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -302,7 +302,7 @@
       throw new Error(error);
     }
 
-    const { price, timestamp, rank, darkPool, sweep, dollarVolume, options = {} } = data;
+    const { price, timestamp, rank, originalRank, darkPool, sweep, dollarVolume, options = {} } = data;
     const validRank = Number.isInteger(rank) && rank >= 1 && rank <= 100;
 
     if (!validRank) {
@@ -332,7 +332,10 @@
     }
 
     const marker = sweep ? '◆' : '●';
-    const labelText = `${marker} VL #${rank}${volLabel}`;
+    const originalRankLabel = options.showOriginalTradeRank && Number.isInteger(originalRank)
+      ? ` (#${originalRank})`
+      : '';
+    const labelText = `${marker} VL #${rank}${originalRankLabel}${volLabel}`;
 
     const overrides = {
       linecolor: color,

--- a/firefox/popup/popup.html
+++ b/firefox/popup/popup.html
@@ -143,6 +143,12 @@
             <option value="5">5px (very thick)</option>
           </select>
         </div>
+        <div class="setting-row">
+          <label class="toggle">
+            <input type="checkbox" id="show-original-trade-rank-toggle">
+            <span>Show original rank on trade labels</span>
+          </label>
+        </div>
       </div>
     </div>
 

--- a/firefox/popup/popup.js
+++ b/firefox/popup/popup.js
@@ -59,6 +59,7 @@ const elements = {
   tradeLitColorInput: document.getElementById('trade-lit-color-input'),
   tradeDarkPoolColorInput: document.getElementById('trade-dark-pool-color-input'),
   tradeThicknessSelect: document.getElementById('trade-thickness-select'),
+  showOriginalTradeRankToggle: document.getElementById('show-original-trade-rank-toggle'),
   yearRangeSelect: document.getElementById('year-range-select'),
   clusteringToggle: document.getElementById('clustering-toggle'),
   thresholdSelect: document.getElementById('threshold-select'),
@@ -98,7 +99,8 @@ async function init() {
   // Load settings
   const stored = await browser.storage.local.get([
     'debugMode', 'levelCount', 'tradeCount', 'yearRange', 'clusteringEnabled', 'clusterThreshold',
-    'lineColor', 'lineThickness', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness'
+    'lineColor', 'lineThickness', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness',
+    'showOriginalTradeRank'
   ]);
   elements.debugToggle.checked = stored.debugMode || false;
   elements.levelCountSelect.value = stored.levelCount ?? 10;
@@ -106,6 +108,7 @@ async function init() {
   elements.tradeLitColorInput.value = stored.tradeLitColor ?? '#2962FF';
   elements.tradeDarkPoolColorInput.value = stored.tradeDarkPoolColor ?? '#FF9800';
   elements.tradeThicknessSelect.value = stored.tradeThickness ?? 2;
+  elements.showOriginalTradeRankToggle.checked = stored.showOriginalTradeRank || false;
   elements.yearRangeSelect.value = stored.yearRange ?? 5;
   elements.clusteringToggle.checked = stored.clusteringEnabled !== false; // Default true
   elements.thresholdSelect.value = stored.clusterThreshold ?? 1.0;
@@ -296,6 +299,7 @@ async function fetchAndDrawTrades() {
     const tradeLitColor = normalizeColorForDraw(elements.tradeLitColorInput?.value, '#2962FF');
     const tradeDarkPoolColor = normalizeColorForDraw(elements.tradeDarkPoolColorInput?.value, '#FF9800');
     const tradeThickness = parseInt(elements.tradeThicknessSelect?.value, 10) || 2;
+    const showOriginalTradeRank = elements.showOriginalTradeRankToggle?.checked || false;
 
     // Send fetch request with tabId - background script handles drawing
     const response = await browser.runtime.sendMessage({
@@ -306,7 +310,8 @@ async function fetchAndDrawTrades() {
       drawOptions: {
         tradeLitColor,
         tradeDarkPoolColor,
-        tradeThickness
+        tradeThickness,
+        showOriginalTradeRank
       }
     });
 
@@ -435,6 +440,12 @@ async function handleTradeThicknessChange() {
   console.log('⚙️ Trade thickness set to:', thickness);
 }
 
+async function handleShowOriginalTradeRankToggle() {
+  const enabled = elements.showOriginalTradeRankToggle.checked;
+  await browser.storage.local.set({ showOriginalTradeRank: enabled });
+  console.log('⚙️ Show original trade rank enabled:', enabled);
+}
+
 /**
  * Handle year range selection change
  */
@@ -534,6 +545,7 @@ function setupEventListeners() {
   elements.tradeLitColorInput.addEventListener('input', handleTradeLitColorChange);
   elements.tradeDarkPoolColorInput.addEventListener('input', handleTradeDarkPoolColorChange);
   elements.tradeThicknessSelect.addEventListener('change', handleTradeThicknessChange);
+  elements.showOriginalTradeRankToggle.addEventListener('change', handleShowOriginalTradeRankToggle);
 
   // Tab switching
   document.querySelectorAll('.tab').forEach(tab => {

--- a/test/background-trade-date-range.test.js
+++ b/test/background-trade-date-range.test.js
@@ -254,6 +254,29 @@ test('trade response maps sweep flag for trade ray labels', async () => {
   assert.equal(result.trades[1].sweep, true);
 });
 
+test('trade response maps TradeRankSnapshot to originalRank', async () => {
+  const context = loadBackground({
+    yearRange: 1,
+    tradesData: [{
+      Date: '/Date(1779148800000)/',
+      Ticker: 'CRDU',
+      Price: 36.8,
+      TradeRank: 10,
+      TradeRankSnapshot: 5,
+      Dollars: 85000000,
+      Volume: 39671,
+      DarkPool: 0,
+      Sweep: 0,
+      FullDateTime: '2026-05-19T09:36:02'
+    }]
+  });
+
+  const result = await context.fetchVlTrades('CRDU', 5, null, new Date('2026-06-08T12:00:00Z'));
+
+  assert.equal(result.trades[0].rank, 10);
+  assert.equal(result.trades[0].originalRank, 5);
+});
+
 test('trade response treats FullDateTime as New York market time', async () => {
   const context = loadBackground({
     yearRange: 1,

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -165,6 +165,46 @@ test('DRAW_NOTE can include original trade rank in label', async () => {
   assert.equal(createShapeCalls[0].config.text, '● VL #10 (#5) $85M');
 });
 
+test('DRAW_NOTE omits original trade rank unless enabled with an integer rank', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return `ray-${createShapeCalls.length}`;
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  const cases = [
+    { originalRank: 5, options: { showOriginalTradeRank: false } },
+    { options: { showOriginalTradeRank: true } },
+    { originalRank: '5', options: { showOriginalTradeRank: true } },
+    { originalRank: 5.5, options: { showOriginalTradeRank: true } },
+    { originalRank: null, options: { showOriginalTradeRank: true } }
+  ];
+
+  for (const testCase of cases) {
+    await injected.send('DRAW_NOTE', {
+      price: 123.45,
+      timestamp: 1712345678,
+      rank: 10,
+      dollarVolume: 85000000,
+      ...testCase
+    });
+  }
+
+  assert.deepEqual(createShapeCalls.map(call => call.config.text), [
+    '● VL #10 $85M',
+    '● VL #10 $85M',
+    '● VL #10 $85M',
+    '● VL #10 $85M',
+    '● VL #10 $85M'
+  ]);
+});
+
 test('DRAW_NOTE only creates shapes for ranks from 1 through 100', async () => {
   const createShapeCalls = [];
   const chart = {

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -138,6 +138,33 @@ test('DRAW_NOTE uses sweep marker and custom trade ray styling', async () => {
   assert.equal(createShapeCalls[1].config.overrides.linewidth, 4);
 });
 
+test('DRAW_NOTE can include original trade rank in label', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return 'ray-1';
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  await injected.send('DRAW_NOTE', {
+    price: 123.45,
+    timestamp: 1712345678,
+    rank: 10,
+    originalRank: 5,
+    dollarVolume: 85000000,
+    options: {
+      showOriginalTradeRank: true
+    }
+  });
+
+  assert.equal(createShapeCalls[0].config.text, '● VL #10 (#5) $85M');
+});
+
 test('DRAW_NOTE only creates shapes for ranks from 1 through 100', async () => {
   const createShapeCalls = [];
   const chart = {


### PR DESCRIPTION
## Summary
- Let users opt into seeing the original VolumeLeaders trade rank when drawing trade rays.
- Keep default trade labels unchanged unless the new Trades setting is enabled.

## Changes
- Add `Show original rank on trade labels` to the Trades settings tab.
- Carry `TradeRankSnapshot` through the trade fetch and draw pipeline as `originalRank`.
- Render labels as `VL #10 (#5) $85M` only when enabled and the snapshot rank is an integer.

## Testing
- [x] `npm test`
- [x] `npm run lint` (0 errors, 1 existing Firefox manifest warning about future data collection permissions)
- [x] Local CodeRabbit review, fixed one test coverage finding

## Related
- None
