### PR TITLE
fix: omit duplicate original trade rank

### DIFF
--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -332,7 +332,7 @@
     }
 
     const marker = sweep ? '◆' : '●';
-    const originalRankLabel = options.showOriginalTradeRank && Number.isInteger(originalRank)
+    const originalRankLabel = options.showOriginalTradeRank && Number.isInteger(originalRank) && originalRank !== rank
       ? ` (#${originalRank})`
       : '';
     const labelText = `${marker} VL #${rank}${originalRankLabel}${volLabel}`;

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -165,6 +165,33 @@ test('DRAW_NOTE can include original trade rank in label', async () => {
   assert.equal(createShapeCalls[0].config.text, '● VL #10 (#5) $85M');
 });
 
+test('DRAW_NOTE omits original trade rank when it matches current rank', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return 'ray-1';
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  await injected.send('DRAW_NOTE', {
+    price: 123.45,
+    timestamp: 1712345678,
+    rank: 2,
+    originalRank: 2,
+    dollarVolume: 85000000,
+    options: {
+      showOriginalTradeRank: true
+    }
+  });
+
+  assert.equal(createShapeCalls[0].config.text, '● VL #2 $85M');
+});
+
 test('DRAW_NOTE omits original trade rank unless enabled with an integer rank', async () => {
   const createShapeCalls = [];
   const chart = {


### PR DESCRIPTION
## Summary
- Avoid redundant original-rank labels when TradeRankSnapshot matches the current trade rank.
- Keep snapshot context visible when the original rank differs from the current rank.

## Changes
- Suppress `(#originalRank)` when `originalRank === rank`.
- Add regression coverage for matching current/original ranks.

## Testing
- [x] `node --test test/injected-trade-rays.test.js`
- [x] `npm test`
- [x] `npm run lint` (0 errors, 1 Mozilla future-manifest notice)
