### PR TITLE
feat: add level line opacity setting

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -581,6 +581,7 @@ async function fetchAndDraw(symbol, tabId = null, drawOptions = {}) {
         options: {
           color: drawOptions.color || '#02A9DE',
           width: drawOptions.width || 2,
+          opacity: drawOptions.opacity ?? 100,
           style: drawOptions.style || 0
         }
       });

--- a/firefox/content-script.js
+++ b/firefox/content-script.js
@@ -179,6 +179,7 @@ if (window !== window.top) {
             options: {
               linecolor: options.color || '#02A9DE',
               linewidth: 4, // Thick line for zones
+              lineopacity: options.opacity ?? 100,
               linestyle: options.style || 0
             }
           });
@@ -202,6 +203,7 @@ if (window !== window.top) {
             options: {
               linecolor: options.color || '#02A9DE',
               linewidth: options.width || 2,
+              lineopacity: options.opacity ?? 100,
               linestyle: options.style || 0
             }
           });

--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -139,6 +139,18 @@
     return ticker;
   }
 
+  function applyOpacity(color, opacity = 100) {
+    const value = Number(opacity);
+    const pct = Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 100;
+
+    if (pct >= 100 || !/^#[0-9A-F]{6}$/i.test(color)) {
+      return color;
+    }
+
+    const hex = color.slice(1);
+    return `rgba(${parseInt(hex.slice(0, 2), 16)}, ${parseInt(hex.slice(2, 4), 16)}, ${parseInt(hex.slice(4, 6), 16)}, ${pct / 100})`;
+  }
+
   /**
    * Draw a horizontal line on the chart
    */
@@ -156,14 +168,16 @@
 
     const { price, label, options = {} } = data;
 
+    const linecolor = applyOpacity(options.linecolor || '#02A9DE', options.lineopacity ?? 100);
+
     // Default styling - VL cyan theme
     // Only pass TradingView-compatible properties (no spread to avoid extra props)
     const overrides = {
-      linecolor: options.linecolor || '#02A9DE',
+      linecolor,
       linewidth: options.linewidth || 2,
       linestyle: options.linestyle || 0, // 0=solid, 1=dotted, 2=dashed
       showLabel: true,
-      textcolor: options.textcolor || options.linecolor || '#02A9DE',
+      textcolor: options.textcolor || linecolor,
       fontsize: options.fontsize || 12,
       bold: options.bold !== false,
       horzLabelsAlign: 'right',
@@ -227,14 +241,16 @@
 
     const { highPrice, lowPrice, midPrice, label, options = {} } = data;
 
+    const linecolor = applyOpacity(options.linecolor || '#02A9DE', options.lineopacity ?? 100);
+
     // Use thick line at midpoint to represent the zone
     // Only pass TradingView-compatible properties (no spread to avoid extra props)
     const overrides = {
-      linecolor: options.linecolor || '#02A9DE',
+      linecolor,
       linewidth: options.linewidth || 4, // Thick line for zones (vs 2 for single levels)
       linestyle: options.linestyle || 0, // Solid
       showLabel: true,
-      textcolor: options.textcolor || options.linecolor || '#02A9DE',
+      textcolor: options.textcolor || linecolor,
       fontsize: options.fontsize || 12,
       bold: options.bold !== false,
       horzLabelsAlign: 'right',

--- a/firefox/popup/popup.html
+++ b/firefox/popup/popup.html
@@ -105,6 +105,15 @@
           </select>
         </div>
         <div class="setting-row">
+          <label for="line-opacity-select">Line opacity:</label>
+          <select id="line-opacity-select" class="setting-select">
+            <option value="100" selected>100% (opaque)</option>
+            <option value="75">75%</option>
+            <option value="50">50%</option>
+            <option value="25">25%</option>
+          </select>
+        </div>
+        <div class="setting-row">
           <label class="toggle">
             <input type="checkbox" id="show-dates-toggle">
             <span>Show date ranges on labels</span>

--- a/firefox/popup/popup.js
+++ b/firefox/popup/popup.js
@@ -66,6 +66,7 @@ const elements = {
   thresholdRow: document.getElementById('threshold-row'),
   lineColorInput: document.getElementById('line-color-input'),
   lineThicknessSelect: document.getElementById('line-thickness-select'),
+  lineOpacitySelect: document.getElementById('line-opacity-select'),
   showDatesToggle: document.getElementById('show-dates-toggle')
 };
 
@@ -99,7 +100,7 @@ async function init() {
   // Load settings
   const stored = await browser.storage.local.get([
     'debugMode', 'levelCount', 'tradeCount', 'yearRange', 'clusteringEnabled', 'clusterThreshold',
-    'lineColor', 'lineThickness', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness',
+    'lineColor', 'lineThickness', 'lineOpacity', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness',
     'showOriginalTradeRank'
   ]);
   elements.debugToggle.checked = stored.debugMode || false;
@@ -114,6 +115,7 @@ async function init() {
   elements.thresholdSelect.value = stored.clusterThreshold ?? 1.0;
   elements.lineColorInput.value = stored.lineColor ?? '#2962FF';
   elements.lineThicknessSelect.value = stored.lineThickness ?? 2;
+  elements.lineOpacitySelect.value = stored.lineOpacity ?? 100;
   elements.showDatesToggle.checked = stored.showDates || false; // Default false
   updateThresholdVisibility();
 
@@ -247,6 +249,7 @@ async function fetchAndDraw() {
       lineColor = '#2962FF';
     }
     const lineThickness = parseInt(elements.lineThicknessSelect?.value, 10) || 2;
+    const lineOpacity = parseInt(elements.lineOpacitySelect?.value, 10) || 100;
 
     const response = await browser.runtime.sendMessage({
       type: 'FETCH_VL_LEVELS',
@@ -255,6 +258,7 @@ async function fetchAndDraw() {
       drawOptions: {
         color: lineColor,
         width: lineThickness,
+        opacity: lineOpacity,
         style: 0
       }
     });
@@ -504,6 +508,12 @@ async function handleLineThicknessChange() {
   console.log('⚙️ Line thickness set to:', thickness);
 }
 
+async function handleLineOpacityChange() {
+  const opacity = parseInt(elements.lineOpacitySelect.value, 10);
+  await browser.storage.local.set({ lineOpacity: opacity });
+  console.log('⚙️ Line opacity set to:', opacity + '%');
+}
+
 /**
  * Handle show dates toggle change
  */
@@ -541,6 +551,7 @@ function setupEventListeners() {
   elements.thresholdSelect.addEventListener('change', handleThresholdChange);
   elements.lineColorInput.addEventListener('input', handleLineColorChange);
   elements.lineThicknessSelect.addEventListener('change', handleLineThicknessChange);
+  elements.lineOpacitySelect.addEventListener('change', handleLineOpacityChange);
   elements.showDatesToggle.addEventListener('change', handleShowDatesToggle);
   elements.tradeLitColorInput.addEventListener('input', handleTradeLitColorChange);
   elements.tradeDarkPoolColorInput.addEventListener('input', handleTradeDarkPoolColorChange);

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -51,6 +51,31 @@ function plain(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+test('DRAW_LINE applies configured opacity to level color', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return 'line-1';
+    }
+  };
+  const injected = loadInjected(chart);
+
+  const response = await injected.send('DRAW_LINE', {
+    price: 123.45,
+    label: 'VL #1',
+    options: {
+      linecolor: '#112233',
+      lineopacity: 50
+    }
+  });
+
+  assert.equal(response.error, null);
+  assert.equal(createShapeCalls.length, 1);
+  assert.equal(createShapeCalls[0].config.overrides.linecolor, 'rgba(17, 34, 51, 0.5)');
+  assert.equal(createShapeCalls[0].config.overrides.textcolor, 'rgba(17, 34, 51, 0.5)');
+});
+
 test('DRAW_NOTE creates a horizontal ray from the actual trade timestamp', async () => {
   const createShapeCalls = [];
   const chart = {


### PR DESCRIPTION
## Summary
- Add a line opacity selector for VL levels, defaulting to 100% opaque.
- Persist the opacity setting and pass it through to level/zone drawing.
- Convert level colors to `rgba(...)` when opacity is below 100%.

## Testing
- `npm test`
- `npm exec -- web-ext lint --source-dir=firefox`
- `npm run build`

Note: direct `npm run lint` fails locally due an ESLint 9 config lookup issue, but the underlying `web-ext lint` command passes with one existing manifest warning.
