### PR TITLE
feat(trades): make label position configurable (left/right)

### DIFF
--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -360,7 +360,8 @@
       showLabel: true,
       textcolor: options.textcolor || color,
       fontsize: options.fontsize || 12,
-      bold: options.bold !== false
+      bold: options.bold !== false,
+      horzLabelsAlign: options.horzLabelsAlign || 'right'
     };
 
     const shapeConfig = {

--- a/firefox/popup/popup.html
+++ b/firefox/popup/popup.html
@@ -158,6 +158,13 @@
             <span>Show original rank on trade labels</span>
           </label>
         </div>
+        <div class="setting-row">
+          <label for="trade-label-position-select">Label position:</label>
+          <select id="trade-label-position-select" class="setting-select">
+            <option value="right" selected>Right</option>
+            <option value="left">Left</option>
+          </select>
+        </div>
       </div>
     </div>
 

--- a/firefox/popup/popup.js
+++ b/firefox/popup/popup.js
@@ -60,6 +60,7 @@ const elements = {
   tradeDarkPoolColorInput: document.getElementById('trade-dark-pool-color-input'),
   tradeThicknessSelect: document.getElementById('trade-thickness-select'),
   showOriginalTradeRankToggle: document.getElementById('show-original-trade-rank-toggle'),
+  tradeLabelPositionSelect: document.getElementById('trade-label-position-select'),
   yearRangeSelect: document.getElementById('year-range-select'),
   clusteringToggle: document.getElementById('clustering-toggle'),
   thresholdSelect: document.getElementById('threshold-select'),
@@ -101,7 +102,7 @@ async function init() {
   const stored = await browser.storage.local.get([
     'debugMode', 'levelCount', 'tradeCount', 'yearRange', 'clusteringEnabled', 'clusterThreshold',
     'lineColor', 'lineThickness', 'lineOpacity', 'showDates', 'tradeLitColor', 'tradeDarkPoolColor', 'tradeThickness',
-    'showOriginalTradeRank'
+    'showOriginalTradeRank', 'tradeLabelPosition'
   ]);
   elements.debugToggle.checked = stored.debugMode || false;
   elements.levelCountSelect.value = stored.levelCount ?? 10;
@@ -117,6 +118,7 @@ async function init() {
   elements.lineThicknessSelect.value = stored.lineThickness ?? 2;
   elements.lineOpacitySelect.value = stored.lineOpacity ?? 100;
   elements.showDatesToggle.checked = stored.showDates || false; // Default false
+  elements.tradeLabelPositionSelect.value = stored.tradeLabelPosition || 'right';
   updateThresholdVisibility();
 
   // Set up event listeners
@@ -304,6 +306,7 @@ async function fetchAndDrawTrades() {
     const tradeDarkPoolColor = normalizeColorForDraw(elements.tradeDarkPoolColorInput?.value, '#FF9800');
     const tradeThickness = parseInt(elements.tradeThicknessSelect?.value, 10) || 2;
     const showOriginalTradeRank = elements.showOriginalTradeRankToggle?.checked || false;
+    const tradeLabelPosition = elements.tradeLabelPositionSelect?.value || 'right';
 
     // Send fetch request with tabId - background script handles drawing
     const response = await browser.runtime.sendMessage({
@@ -315,7 +318,8 @@ async function fetchAndDrawTrades() {
         tradeLitColor,
         tradeDarkPoolColor,
         tradeThickness,
-        showOriginalTradeRank
+        showOriginalTradeRank,
+        horzLabelsAlign: tradeLabelPosition
       }
     });
 
@@ -450,6 +454,12 @@ async function handleShowOriginalTradeRankToggle() {
   console.log('⚙️ Show original trade rank enabled:', enabled);
 }
 
+async function handleTradeLabelPositionChange() {
+  const position = elements.tradeLabelPositionSelect.value;
+  await browser.storage.local.set({ tradeLabelPosition: position });
+  console.log('⚙️ Trade label position set to:', position);
+}
+
 /**
  * Handle year range selection change
  */
@@ -557,6 +567,7 @@ function setupEventListeners() {
   elements.tradeDarkPoolColorInput.addEventListener('input', handleTradeDarkPoolColorChange);
   elements.tradeThicknessSelect.addEventListener('change', handleTradeThicknessChange);
   elements.showOriginalTradeRankToggle.addEventListener('change', handleShowOriginalTradeRankToggle);
+  elements.tradeLabelPositionSelect.addEventListener('change', handleTradeLabelPositionChange);
 
   // Tab switching
   document.querySelectorAll('.tab').forEach(tab => {

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -257,6 +257,51 @@ test('DRAW_NOTE omits original trade rank unless enabled with an integer rank', 
   ]);
 });
 
+test('DRAW_NOTE applies horzLabelsAlign from options with right as default', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return `ray-${createShapeCalls.length}`;
+    },
+    getVisibleRange() {
+      return { from: 1700000000, to: 1800000000 };
+    }
+  };
+  const injected = loadInjected(chart);
+
+  // Default (no option) should be right
+  await injected.send('DRAW_NOTE', {
+    price: 10,
+    timestamp: 1712345678,
+    rank: 1,
+    dollarVolume: 1000
+  });
+
+  // Explicit left
+  await injected.send('DRAW_NOTE', {
+    price: 20,
+    timestamp: 1712345678,
+    rank: 2,
+    dollarVolume: 2000,
+    options: { horzLabelsAlign: 'left' }
+  });
+
+  // Explicit right
+  await injected.send('DRAW_NOTE', {
+    price: 30,
+    timestamp: 1712345678,
+    rank: 3,
+    dollarVolume: 3000,
+    options: { horzLabelsAlign: 'right' }
+  });
+
+  assert.equal(createShapeCalls.length, 3);
+  assert.equal(createShapeCalls[0].config.overrides.horzLabelsAlign, 'right');
+  assert.equal(createShapeCalls[1].config.overrides.horzLabelsAlign, 'left');
+  assert.equal(createShapeCalls[2].config.overrides.horzLabelsAlign, 'right');
+});
+
 test('DRAW_NOTE only creates shapes for ranks from 1 through 100', async () => {
   const createShapeCalls = [];
   const chart = {


### PR DESCRIPTION
## Summary

Add a label position selector for trade rays — Right (default) or Left. Trades only; levels are unchanged.

## Testing

- `npm test` — 18/18 pass (1 new test verifying default right, explicit left, explicit right)
- `npm run lint` — clean (1 existing manifest warning)
