### PR TITLE
feat(levels): anchor trade level rays to first-trade date

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -69,6 +69,24 @@ function parseVlFullDateTime(fullDateTime) {
 }
 
 /**
+ * Parse a VolumeLeaders date into Unix seconds. Trade levels use MinDate in
+ * .NET JSON form (/Date(1748563200000)/), but accept normalized numeric
+ * timestamps too so older or malformed responses retain line fallback.
+ */
+function parseVlTimestamp(value) {
+  if (value === null || value === undefined || value === '') return null;
+
+  const dotNetMatch = typeof value === 'string' && value.match(/^\/Date\((-?\d+)(?:[+-]\d+)?\)\/$/);
+  const numericValue = dotNetMatch ? Number(dotNetMatch[1]) : Number(value);
+  if (!Number.isFinite(numericValue)) return null;
+
+  // Milliseconds are used by .NET JSON and Date.now(); normalized values are
+  // already Unix seconds.
+  const timestamp = Math.abs(numericValue) >= 1e11 ? numericValue / 1000 : numericValue;
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null;
+}
+
+/**
  * Initialize extension
  */
 async function init() {
@@ -519,7 +537,8 @@ async function fetchVlLevels(ticker, now = new Date()) {
       dollars: item.Dollars || item.dollars,
       volume: item.Volume || item.volume,
       trades: item.Trades || item.trades,
-      dates: item.Dates || item.dates
+      dates: item.Dates || item.dates,
+      timestamp: parseVlTimestamp(item.MinDate ?? item.minDate)
     })).filter(l => l.price && typeof l.price === 'number');
 
     console.log(`📊 Fetched ${levels.length} levels for ${ticker}`);
@@ -981,6 +1000,7 @@ function finalizeCluster(levels) {
   const prices = levels.map(l => l.price);
   const ranks = levels.map(l => l.rank).filter(Boolean).sort((a, b) => a - b);
   const totalDollars = levels.reduce((sum, l) => sum + (l.dollars || 0), 0);
+  const timestamps = levels.map(l => l.timestamp).filter(timestamp => Number.isFinite(timestamp) && timestamp > 0);
   const highPrice = Math.max(...prices);
   const lowPrice = Math.min(...prices);
 
@@ -989,6 +1009,7 @@ function finalizeCluster(levels) {
     highPrice,
     lowPrice,
     midPrice: (highPrice + lowPrice) / 2,
+    timestamp: timestamps.length > 0 ? Math.min(...timestamps) : null,
     levels,
     aggregated: {
       rankRange: ranks.length > 0 ? [ranks[0], ranks[ranks.length - 1]] : [null, null],

--- a/firefox/content-script.js
+++ b/firefox/content-script.js
@@ -175,6 +175,7 @@ if (window !== window.top) {
             highPrice: item.highPrice,
             lowPrice: item.lowPrice,
             midPrice: item.midPrice,
+            timestamp: item.timestamp,
             label: item.label,
             options: {
               linecolor: options.color || '#02A9DE',
@@ -199,6 +200,7 @@ if (window !== window.top) {
           // Draw single level as normal line
           result = await sendToInjected('DRAW_LINE', {
             price: item.price,
+            timestamp: item.timestamp,
             label: item.label || `VL ${item.price}`,
             options: {
               linecolor: options.color || '#02A9DE',

--- a/firefox/injected.js
+++ b/firefox/injected.js
@@ -166,7 +166,8 @@
       throw new Error(error);
     }
 
-    const { price, label, options = {} } = data;
+    const { price, timestamp, label, options = {} } = data;
+    const hasValidTimestamp = Number.isFinite(timestamp) && timestamp > 0;
 
     const linecolor = applyOpacity(options.linecolor || '#02A9DE', options.lineopacity ?? 100);
 
@@ -187,7 +188,7 @@
     console.log('🎨 INJECTED: Line overrides:', JSON.stringify(overrides));
 
     const shapeConfig = {
-      shape: 'horizontal_line',
+      shape: hasValidTimestamp ? 'horizontal_ray' : 'horizontal_line',
       text: label || `VL ${price}`,
       overrides: overrides
     };
@@ -196,7 +197,7 @@
 
     try {
       const shapeId = await chart.createShape(
-        { price: price },
+        hasValidTimestamp ? { price: price, time: timestamp } : { price: price },
         shapeConfig
       );
 
@@ -239,7 +240,8 @@
       throw new Error(error);
     }
 
-    const { highPrice, lowPrice, midPrice, label, options = {} } = data;
+    const { highPrice, lowPrice, midPrice, timestamp, label, options = {} } = data;
+    const hasValidTimestamp = Number.isFinite(timestamp) && timestamp > 0;
 
     const linecolor = applyOpacity(options.linecolor || '#02A9DE', options.lineopacity ?? 100);
 
@@ -260,7 +262,7 @@
     console.log('🎨 INJECTED: Zone overrides:', JSON.stringify(overrides));
 
     const shapeConfig = {
-      shape: 'horizontal_line',
+      shape: hasValidTimestamp ? 'horizontal_ray' : 'horizontal_line',
       text: label || `VL Zone [${lowPrice.toFixed(2)}-${highPrice.toFixed(2)}]`,
       overrides: overrides
     };
@@ -269,7 +271,7 @@
 
     try {
       const shapeId = await chart.createShape(
-        { price: midPrice },
+        hasValidTimestamp ? { price: midPrice, time: timestamp } : { price: midPrice },
         shapeConfig
       );
 
@@ -483,8 +485,8 @@
 
       for (const shape of allShapes) {
         try {
-          // Only target horizontal_line shapes
-          if (shape.name !== 'horizontal_line') continue;
+          // Target level/zone lines and rays, but leave trade rays intact.
+          if (shape.name !== 'horizontal_line' && shape.name !== 'horizontal_ray') continue;
 
           // Get shape properties to check the text
           const shapeObj = chart.getShapeById(shape.id);

--- a/test/background-trade-date-range.test.js
+++ b/test/background-trade-date-range.test.js
@@ -29,7 +29,7 @@ function loadBackground(settings = {}) {
           ok: true,
           status: 200,
           json: async () => ({
-            data: [{ Price: 36.8, TradeLevelRank: 1, Dollars: 1459892.8, Volume: 39671, Trades: 1, Dates: '2026-05-19 - 2026-05-19' }]
+            data: settings.levelsData || [{ Price: 36.8, TradeLevelRank: 1, Dollars: 1459892.8, Volume: 39671, Trades: 1, Dates: '2026-05-19 - 2026-05-19' }]
           })
         };
       }
@@ -358,4 +358,25 @@ test('level request matches the VolumeLeaders Chart0 GetTradeLevels HAR shape', 
   assert.equal(levelRequest.options.headers.Referer, 'https://www.volumeleaders.com/Chart0?StartDate=2025-06-08&EndDate=2026-06-08&Ticker=CRDU&MinVolume=0&MaxVolume=2000000000&MinDollars=500000&MaxDollars=30000000000&MinPrice=0&MaxPrice=100000&DarkPools=-1&Sweeps=-1&LatePrints=-1&SignaturePrints=-1&VolumeProfile=0&Levels=5&TradeCount=3&VCD=0&TradeRank=-1&TradeRankSnapshot=-1&IncludePremarket=1&IncludeRTH=1&IncludeAH=1&IncludeOpening=1&IncludeClosing=1&IncludePhantom=1&IncludeOffsetting=1');
   assert.deepEqual(body, expectedBody);
   assert.equal(result.levels[0].price, 36.8);
+});
+
+test('levels parse MinDate and propagate the earliest clustered anchor to drawing', async () => {
+  const context = loadBackground({
+    clusteringEnabled: true,
+    clusterThreshold: 1,
+    levelsData: [
+      { Price: 100, TradeLevelRank: 1, Dollars: 1000000, Dates: '2026-05-19 - 2026-05-19', MinDate: '/Date(1779148800000)/' },
+      { Price: 100.5, TradeLevelRank: 2, Dollars: 1000000, Dates: '2026-05-20 - 2026-05-20', MinDate: 1779062400 },
+      { Price: 110, TradeLevelRank: 3, Dollars: 1000000, Dates: '2026-05-21 - 2026-05-21', MinDate: 'invalid' }
+    ]
+  });
+
+  const levels = await context.fetchVlLevels('CRDU', new Date('2026-06-08T12:00:00Z'));
+  assert.deepEqual(levels.levels.map(level => level.timestamp), [1779148800, 1779062400, null]);
+
+  await context.fetchAndDraw('CRDU', 123);
+  const drawMessage = context.tabMessages.find(entry => entry.message.type === 'DRAW_LEVELS').message;
+  assert.equal(drawMessage.levels[0].type, 'zone');
+  assert.equal(drawMessage.levels[0].timestamp, 1779062400);
+  assert.equal(drawMessage.levels[1].timestamp, null);
 });

--- a/test/injected-trade-rays.test.js
+++ b/test/injected-trade-rays.test.js
@@ -76,6 +76,25 @@ test('DRAW_LINE applies configured opacity to level color', async () => {
   assert.equal(createShapeCalls[0].config.overrides.textcolor, 'rgba(17, 34, 51, 0.5)');
 });
 
+test('DRAW_LINE and DRAW_ZONE create rays from valid timestamps and lines otherwise', async () => {
+  const createShapeCalls = [];
+  const chart = {
+    createShape(point, config) {
+      createShapeCalls.push({ point, config });
+      return `shape-${createShapeCalls.length}`;
+    }
+  };
+  const injected = loadInjected(chart);
+
+  await injected.send('DRAW_LINE', { price: 100, timestamp: 1712345678, label: 'VL #1' });
+  await injected.send('DRAW_ZONE', { highPrice: 101, lowPrice: 99, midPrice: 100, timestamp: null, label: 'VL #1,2' });
+
+  assert.deepEqual(plain(createShapeCalls[0].point), { price: 100, time: 1712345678 });
+  assert.equal(createShapeCalls[0].config.shape, 'horizontal_ray');
+  assert.deepEqual(plain(createShapeCalls[1].point), { price: 100 });
+  assert.equal(createShapeCalls[1].config.shape, 'horizontal_line');
+});
+
 test('DRAW_NOTE creates a horizontal ray from the actual trade timestamp', async () => {
   const createShapeCalls = [];
   const chart = {
@@ -372,4 +391,22 @@ test('CLEAR_VL_NOTES removes existing VL horizontal rays and legacy notes', asyn
   assert.equal(response.error, null);
   assert.deepEqual(plain(response.result), { removed: 2 });
   assert.deepEqual(removed, ['ray-1', 'note-1']);
+});
+
+test('CLEAR_VL_LINES removes VL level rays and lines without removing trade rays', async () => {
+  const removed = [];
+  const chart = {
+    getAllShapes: () => [
+      { id: 'level-ray', name: 'horizontal_ray' },
+      { id: 'level-line', name: 'horizontal_line' },
+      { id: 'trade-ray', name: 'horizontal_ray' }
+    ],
+    getShapeById: id => ({ getProperties: () => ({ text: id === 'trade-ray' ? '● VL #1 $1B' : 'VL #1 $1B' }) }),
+    removeEntity: id => removed.push(id)
+  };
+  const injected = loadInjected(chart);
+
+  const response = await injected.send('CLEAR_VL_LINES');
+  assert.deepEqual(plain(response.result), { removed: 2 });
+  assert.deepEqual(removed, ['level-ray', 'level-line']);
 });


### PR DESCRIPTION
## What

Trade levels now draw as rays anchored to the date of the first trade that contributed to that level, matching how we already draw trade rays. Previously level lines always spanned the full chart width regardless of when the level actually formed.

## Why

We recently switched trade markers to timestamp-anchored rays. Levels were still using full-width lines, so a level that only existed for the last year of a stock's history looked identical to one that's been relevant for a decade. VolumeLeaders' `GetTradeLevels` response already includes a `MinDate` per level (first contributing trade), so we can anchor the same way.

## Changes

- Parse `MinDate` (`.NET /Date(ms)/` form) into a Unix-second timestamp per level.
- Draw single levels as `horizontal_ray` starting at that timestamp instead of `horizontal_line`.
- For clustered zones, anchor at the earliest valid timestamp among the zone's member levels.
- Fall back to the old full-width `horizontal_line` when no valid timestamp is available (malformed or legacy response data), so this can't crash or silently drop a level.
- Updated cleanup to remove both `horizontal_line` and `horizontal_ray` level/zone drawings on redraw, without touching trade rays (still discriminated by label prefix).

## Testing

- `npm test` — 21/21 passing, including new coverage for `MinDate` parsing, clustered-zone anchor selection, ray-vs-line fallback, and cleanup scoping.
- `npm run lint` — clean (one pre-existing, unrelated manifest notice).
- Manually verified against a captured HAR (`GetTradeLevels` response) showing `MinDate` values spread across multiple years per level.
